### PR TITLE
Fixed last location on new character created

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -287,6 +287,12 @@ RegisterNetEvent('qbr-spawn:client:setupSpawns', function(cData, new, apps)
             action = "setupAppartements",
             locations = apps,
         })
+    elseif new then 
+        SendNUIMessage({
+            action = "setupLocations",
+            locations = QB.FirstSpawns ,
+            new = true,
+        })
     else
         SendNUIMessage({
             action = "setupLocations",

--- a/config.lua
+++ b/config.lua
@@ -6,6 +6,29 @@ QB.EnableHouses = false
 -- Enable spawning inside apartments from the spawn selector
 QB.EnableApartments = false
 
+QB.FirstSpawns = {
+    ["emerald"] = {
+        coords = {
+            x = 1417.818,
+            y = 268.0298,
+            z = 89.61942,
+            h = 144.5
+        },
+        location = "emerald",
+        label = "Emerald Ranch Fence",
+    },
+    ["rhodesst"] = {
+        coords = {
+            x = 1359.575,
+            y = -1301.451,
+            z = 77.76775,
+            h = 3.5
+        },
+        location = "rhodesst",
+        label = "Rhodes Sheriff Station",
+    },
+}
+
 QB.Spawns = {
     ["emerald"] = {
         coords = {

--- a/html/script.js
+++ b/html/script.js
@@ -14,7 +14,8 @@ $(document).ready(function() {
         }
 
         if (data.action == "setupLocations") {
-            setupLocations(data.locations, data.houses)
+            var isNew = data.new;
+            setupLocations(data.locations, data.houses, isNew)
         }
 
         if (data.action == "setupAppartements") {
@@ -67,14 +68,16 @@ $(document).on('click', '#submit-spawn', function(evt) {
     }
 });
 
-function setupLocations(locations, myHouses) {
+function setupLocations(locations, myHouses, isNew) {
     var parent = $('.spawn-locations')
     $(parent).html("");
     $(parent).append('<div class="loclabel" id="location" data-location="null" data-type="lab" data-label="Where would you like to start?"><p><span id="null">Where would you like to start?</span></p></div>')
 
     setTimeout(function() {
-        $(parent).append('<div class="location" id="location" data-location="current" data-type="current" data-label="Last Location"><p><span id="current-location">Last Location</span></p></div>');
-
+        if (!isNew){
+            $(parent).append('<div class="location" id="location" data-location="current" data-type="current" data-label="Last Location"><p><span id="current-location">Last Location</span></p></div>');
+        }
+        
         $.each(locations, function(index, location) {
             $(parent).append('<div class="location" id="location" data-location="' + location.location + '" data-type="normal" data-label="' + location.label + '"><p><span id="' + location.location + '">' + location.label + '</span></p></div>')
         });


### PR DESCRIPTION
Issue: When creating a new character, the last location option shows up in the menu. Breaking upon clicking?

Fix: Passed new through nui and skipped last location append if true

Expected result: Last location no longer shows up when creating a new character. However, it shows up once logged out and back in as expected 

------------------------------------------------------------------------------------------------------------------------------------------------------------

Also added a feature for flexibility and customization.

Issue: If i wanted to have an initial spawn location(s) but restrict the player to only his last location or some set of other locations, I could not.

Fix: Created another table to separate out the initial new character spawn locations vs regular character spawn locations.

Result: Initial spawn locations can now be set independently from the regular character spawn locations