### PR TITLE
Fix Spawn Bug for Non New Players

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -172,7 +172,10 @@ RegisterNUICallback('spawnplayer', function(data)
         Wait(500)
         DoScreenFadeIn(250)
     elseif type == "normal" then
-        local pos = QB.FirstSpawns[location].coords
+        local pos = QB.Spawns[location].coords
+        if newPlayer then
+            pos = QB.FirstSpawns[location].coords
+        end
         SetDisplay(false)
         DoScreenFadeOut(500)
         Wait(2000)

--- a/client.lua
+++ b/client.lua
@@ -172,9 +172,12 @@ RegisterNUICallback('spawnplayer', function(data)
         Wait(500)
         DoScreenFadeIn(250)
     elseif type == "normal" then
-        local pos = QB.Spawns[location].coords
+        local pos = {}
+
         if newPlayer then
             pos = QB.FirstSpawns[location].coords
+        else
+            pos = QB.Spawns[location].coords
         end
         SetDisplay(false)
         DoScreenFadeOut(500)


### PR DESCRIPTION
There was no checking if spawn is a newPlayer and was always referencing the First Spawn locations even though it had listed all the other spawns.